### PR TITLE
added ferox-config.toml to install formula

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+install:
+	brew uninstall feroxbuster || :
+	brew install --build-from-source feroxbuster.rb

--- a/feroxbuster.rb
+++ b/feroxbuster.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'etc'
-
 class Feroxbuster < Formula
   desc 'Fast, simple, recursive content discovery tool written in Rust. 🦀'
   homepage 'https://github.com/epi052/feroxbuster'
@@ -14,16 +12,15 @@ class Feroxbuster < Formula
   end
 
   def install
-    config = 'ferox-config.toml'
-    example = 'ferox-config.toml.example'
-    config_dir = "#{Etc.getpwuid.dir}/Library/Application Support/feroxbuster"
+    config = "#{bin}/ferox-config.toml"
+    example = "#{bin}/ferox-config.toml.example"
 
     bin.install 'feroxbuster'
 
-    resource('ferox-config').stage do
-      system 'mkdir', '-p', config_dir
-      system 'cp', '-n', example, "#{config_dir}/#{config}"
-    end
+    resource('ferox-config').stage {
+      bin.install resource('ferox-config')
+      system 'cp', '-n', example, config
+    }
   end
 
   test do

--- a/feroxbuster.rb
+++ b/feroxbuster.rb
@@ -1,27 +1,29 @@
+# frozen_string_literal: true
+
 require 'etc'
 
 class Feroxbuster < Formula
-  desc "Fast, simple, recursive content discovery tool written in Rust. 🦀"
-  homepage "https://github.com/epi052/feroxbuster"
-  url "https://github.com/epi052/feroxbuster/releases/download/v1.0.3/x86_64-macos-feroxbuster.tar.gz"
-  sha256 "2fe01730b28a925d3542ea53bc2fcebd659f1c861235b9d8f8492c2c661d35a7"
+  desc 'Fast, simple, recursive content discovery tool written in Rust. 🦀'
+  homepage 'https://github.com/epi052/feroxbuster'
+  url 'https://github.com/epi052/feroxbuster/releases/download/v1.0.3/x86_64-macos-feroxbuster.tar.gz'
+  sha256 '2fe01730b28a925d3542ea53bc2fcebd659f1c861235b9d8f8492c2c661d35a7'
 
-  resource "ferox-config" do
-    url "https://raw.githubusercontent.com/epi052/feroxbuster/master/ferox-config.toml.example"
-    sha256 "70ace4e70c7f532cc4f7e7958106d035c62bd9d12a6a91de433b815f607911ba"
+  resource 'ferox-config' do
+    url 'https://raw.githubusercontent.com/epi052/feroxbuster/master/ferox-config.toml.example'
+    sha256 '70ace4e70c7f532cc4f7e7958106d035c62bd9d12a6a91de433b815f607911ba'
   end
 
   def install
-    config = "ferox-config.toml"
-    example = "ferox-config.toml.example"
+    config = 'ferox-config.toml'
+    example = 'ferox-config.toml.example'
     config_dir = "#{Etc.getpwuid.dir}/Library/Application Support/feroxbuster"
 
-    bin.install "feroxbuster"
+    bin.install 'feroxbuster'
 
-    resource("ferox-config").stage {
-        system "mkdir", "-p", config_dir
-        system "cp", "-n", example, "#{config_dir}/#{config}"
-    }
+    resource('ferox-config').stage do
+      system 'mkdir', '-p', config_dir
+      system 'cp', '-n', example, "#{config_dir}/#{config}"
+    end
   end
 
   test do

--- a/feroxbuster.rb
+++ b/feroxbuster.rb
@@ -17,10 +17,10 @@ class Feroxbuster < Formula
 
     bin.install 'feroxbuster'
 
-    resource('ferox-config').stage {
+    resource('ferox-config').stage do
       bin.install resource('ferox-config')
       system 'cp', '-n', example, config
-    }
+    end
   end
 
   test do

--- a/feroxbuster.rb
+++ b/feroxbuster.rb
@@ -3,8 +3,8 @@
 class Feroxbuster < Formula
   desc 'Fast, simple, recursive content discovery tool written in Rust. 🦀'
   homepage 'https://github.com/epi052/feroxbuster'
-  url 'https://github.com/epi052/feroxbuster/releases/download/v1.0.3/x86_64-macos-feroxbuster.tar.gz'
-  sha256 '2fe01730b28a925d3542ea53bc2fcebd659f1c861235b9d8f8492c2c661d35a7'
+  url 'https://github.com/epi052/feroxbuster/releases/download/v1.0.4/x86_64-macos-feroxbuster.tar.gz'
+  sha256 'bf939b79c89bcc425320e27822c225c7c06733e30586014612138eda557cfef5'
 
   resource 'ferox-config' do
     url 'https://raw.githubusercontent.com/epi052/feroxbuster/master/ferox-config.toml.example'

--- a/feroxbuster.rb
+++ b/feroxbuster.rb
@@ -1,11 +1,27 @@
+require 'etc'
+
 class Feroxbuster < Formula
   desc "Fast, simple, recursive content discovery tool written in Rust. 🦀"
   homepage "https://github.com/epi052/feroxbuster"
   url "https://github.com/epi052/feroxbuster/releases/download/v1.0.3/x86_64-macos-feroxbuster.tar.gz"
   sha256 "2fe01730b28a925d3542ea53bc2fcebd659f1c861235b9d8f8492c2c661d35a7"
 
+  resource "ferox-config" do
+    url "https://raw.githubusercontent.com/epi052/feroxbuster/master/ferox-config.toml.example"
+    sha256 "70ace4e70c7f532cc4f7e7958106d035c62bd9d12a6a91de433b815f607911ba"
+  end
+
   def install
+    config = "ferox-config.toml"
+    example = "ferox-config.toml.example"
+    config_dir = "#{Etc.getpwuid.dir}/Library/Application Support/feroxbuster"
+
     bin.install "feroxbuster"
+
+    resource("ferox-config").stage {
+        system "mkdir", "-p", config_dir
+        system "cp", "-n", example, "#{config_dir}/#{config}"
+    }
   end
 
   test do


### PR DESCRIPTION
Of note:
- i use `cp -n` to not overwrite an existing file, though I'm not sure if that's valid on a mac
- i use `mkdir -p` so there are no errors if the directory exists, though again, i'm not sure if this translates from linux to mac
- i use `/Users/USER/Library/Application Support/feroxbuster` based on [this library](https://docs.rs/dirs/3.0.1/dirs/fn.config_dir.html), I'm not sure if it exists by default or not

